### PR TITLE
fix: use VITE_ env prefix in typesense instantsearch adapter

### DIFF
--- a/src/utils/typesense.ts
+++ b/src/utils/typesense.ts
@@ -2,12 +2,12 @@ import TypesenseInstantSearchAdapter from 'typesense-instantsearch-adapter';
 
 export const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
   server: {
-    apiKey: import.meta.env.PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY || 'xyz',
+    apiKey: import.meta.env.VITE_TYPESENSE_SEARCH_ONLY_API_KEY || 'xyz',
     nodes: [
       {
-        host: import.meta.env.PUBLIC_TYPESENSE_HOST || 'localhost',
-        port: parseInt(import.meta.env.PUBLIC_TYPESENSE_PORT || '8108'),
-        protocol: import.meta.env.PUBLIC_TYPESENSE_PROTOCOL || 'http',
+        host: import.meta.env.VITE_TYPESENSE_HOST || 'localhost',
+        port: parseInt(import.meta.env.VITE_TYPESENSE_PORT || '8108'),
+        protocol: import.meta.env.VITE_TYPESENSE_PROTOCOL || 'http',
       },
     ],
   },


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
